### PR TITLE
Remove scipy

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,4 +16,3 @@
     - python-pip
     - python-tables
     - PyYAML
-    - scipy


### PR DESCRIPTION
Remove dependency no longer required for 5.4.0
See https://github.com/openmicroscopy/openmicroscopy/pull/5412

This is a breaking change
a new tag will be needed